### PR TITLE
Add catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,10 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: AngularJS
+  annotations:
+    github.com/project-slug: AndrienkoAleksandr/AngularJS
+spec:
+  type: other
+  lifecycle: unknown
+  owner: user:default/test-user


### PR DESCRIPTION
This PR adds a default catalog-info.yaml for Backstage.