### PR TITLE
Add catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -6,5 +6,5 @@ metadata:
     github.com/project-slug: AndrienkoAleksandr/AngularJS
 spec:
   type: other
+  owner: AndrienkoAleksandr
   lifecycle: unknown
-  owner: user:default/andrienkoaleksandr


### PR DESCRIPTION
This PR adds a default catalog-info.yaml for Backstage.